### PR TITLE
Remove literal string warning from Ruby 3.5

### DIFF
--- a/lib/terrapin/command_line/multi_pipe.rb
+++ b/lib/terrapin/command_line/multi_pipe.rb
@@ -39,7 +39,7 @@ module Terrapin
       end
 
       def read_stream(io)
-        result = ""
+        result = +''
         while partial_result = io.read(8192)
           result << partial_result
         end


### PR DESCRIPTION
Fix to remove the literal string warning from Ruby 3.5

The base branch is the [v0.6.0](https://github.com/thoughtbot/terrapin/releases/tag/v0.6.0) tag, as it is the one used for `kt-paperclip`, the gem that brings this dependency: https://github.com/meetcleo/terrapin/tree/6-0-version

https://rubyreferences.github.io/rubychanges/3.4.html#warning-to-prepare-for-freezing-string-literals-in-ruby-35